### PR TITLE
Affiliation names in filter box should not be doubled up #17

### DIFF
--- a/src/features/results/components/affiliation-filter.tsx
+++ b/src/features/results/components/affiliation-filter.tsx
@@ -78,7 +78,7 @@ const AffiliationFilter = ({
                   htmlFor={check_id}
                   className="text-base text-text-primary cursor-pointer"
                 >
-                  {affiliation_id} - {filter.affiliation_name}
+                  {filter.affiliation_name}
                 </label>
               </div>
             );


### PR DESCRIPTION
https://github.com/ModernVivo/mv-frontend/issues/17